### PR TITLE
COMP: Fix packaging of RigidAlignmentModuleMetadata on windows

### DIFF
--- a/Modules/Scripted/RigidAlignmentModule/CMakeLists.txt
+++ b/Modules/Scripted/RigidAlignmentModule/CMakeLists.txt
@@ -20,7 +20,6 @@ configure_file(
 slicerMacroBuildScriptedModule(
   NAME ${MODULE_NAME}Metadata
   SCRIPTS ${MODULE_METADATA_SCRIPT}
-  WITH_SUBDIR
   )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This commit fixes a regression introduced in 37c1a3003 (COMP: Support customization of RigidAlignmentModule title and category).

It removes the use of `WITH_SUBDIR` which generated an incorrect install rules attempting to install the non-existent directory `/path/to/lib/Slicer-4.13/qt-scripted-modules/RigidAlignmentModule`.

It turns out only the windows packaging was failing because it seems to be the only platform where attempting to use the following install command specifying a nonexistent directory is failing:

```
  file(
    INSTALL DESTINATION "/path/to/install/lib/Slicer-4.13/qt-scripted-modules"
    TYPE DIRECTORY FILES
      "/path/to/build/SPHARM-PDM-build/lib/Slicer-4.13/qt-scripted-modules/RigidAlignmentModule" USE_SOURCE_PERMISSIONS)
```