### PR TITLE
BUG: Allow running on Windows

### DIFF
--- a/Modules/Scripted/RigidAlignmentModule/RigidAlignmentModule.py
+++ b/Modules/Scripted/RigidAlignmentModule/RigidAlignmentModule.py
@@ -141,7 +141,7 @@ class RigidAlignmentModuleLogic(ScriptedLoadableModuleLogic):
 
     temp = pathlib.Path(slicer.util.tempDirectory(key='RigidAlignment'))
 
-    now = datetime.datetime.now().isoformat()
+    now = datetime.datetime.now().isoformat().replace(':', '-')
     inputCSV = temp / '{}.csv'.format(now)
 
     with inputCSV.open('w', newline='') as f:
@@ -176,7 +176,9 @@ class RigidAlignmentModuleLogic(ScriptedLoadableModuleLogic):
     }
 
     logging.info('Launching RigidAlignment Module.')
-    slicer.cli.run(slicer.modules.rigidalignment, None, args, wait_for_completion=True)
+    cliNode = slicer.cli.run(slicer.modules.rigidalignment, None, args, wait_for_completion=True)
+    if cliNode.GetStatus() & cliNode.ErrorsMask:
+      raise Exception('Error running RigidAlignment, check error log for details')
     logging.info('RigidAlignment Completed.')
 
   def runSurfRemesh(self, sphere, model, unitSphere, outModel):


### PR DESCRIPTION
The isoformat of datetime has colons between hour, minute, second, so it is not able to be used as a filename on Windows, although it is fine for Linux. Replacing : with - allows cross platform filenames.

Also checking the result of the RigidAlignment CLI to prevent a possible segfault if there is a failure.